### PR TITLE
Amount to decimal

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -2,6 +2,7 @@ package braintree
 
 import (
 	"bytes"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -103,4 +104,10 @@ func (d *Decimal) String() string {
 	}
 
 	return string(b)
+}
+
+// EncodeValues encodes URL query string parameters for the go-querystring library.
+func (d *Decimal) EncodeValues(key string, v *url.Values) error {
+	v.Add(key, d.String())
+	return nil
 }

--- a/transaction.go
+++ b/transaction.go
@@ -103,7 +103,7 @@ type Transaction struct {
 type TransactionURLRequest struct {
 	CustomerID          string                      `url:"customer_id,omitempty"`
 	Type                string                      `url:"type,omitempty"`
-	Amount              string                      `url:"amount,omitempty"`
+	Amount              *Decimal                    `url:"amount,omitempty"`
 	OrderId             string                      `url:"order_id,omitempty"`
 	PaymentMethodToken  string                      `url:"payment_method_token,omitempty"`
 	PaymentMethodNonce  string                      `url:"payment_method_nonce,omitempty"`

--- a/transparent_redirect_gateway_test.go
+++ b/transparent_redirect_gateway_test.go
@@ -69,7 +69,7 @@ func TestTransactionData(t *testing.T) {
 	if !strings.Contains(data, "redirect_url=http%3A%2F%2Fcall.me") {
 		t.Errorf("expected data to contain '%s' but didn't: %s", "redirect_url=http%3A%2F%2Fcall.me", data)
 	}
-	if !strings.Contains(data, "transaction%5Bamount%5D=20") {
+	if !strings.Contains(data, "transaction%5Bamount%5D=20.00") {
 		t.Errorf("expected data to contain '%s' but didn't: %s", "transaction%5Bamount%5D=20", data)
 	}
 	split := strings.Split(data, "|")

--- a/transparent_redirect_gateway_test.go
+++ b/transparent_redirect_gateway_test.go
@@ -57,7 +57,7 @@ func TestTransactionData(t *testing.T) {
 	data, err := tr.TransactionData(&TransparentRedirectData{
 		RedirectURL: "http://call.me",
 		Transaction: TransactionURLRequest{
-			Amount: "20",
+			Amount: NewDecimal(2000, 2),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Use Decimal type for amount rather than string.

This is made possible by the EncodeValues function, which is expected by the go-querystring library:
https://github.com/google/go-querystring/blob/master/query/encode.go